### PR TITLE
move network/audio thread code out of MusicService

### DIFF
--- a/src/main/java/com/kaytat/simpleprotocolplayer/BufferToAudioTrackThread.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/BufferToAudioTrackThread.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ * Copyright (C) 2014 kaytat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kaytat.simpleprotocolplayer;
+
+import android.media.AudioTrack;
+import android.util.Log;
+
+/**
+ * Worker thread that takes data from the buffer and sends it to audio track
+ */
+class BufferToAudioTrackThread extends ThreadStoppable {
+    final String TAG;
+
+    private WorkerThreadPair syncObject;
+
+    public BufferToAudioTrackThread(WorkerThreadPair syncObject, String debugTag) {
+        this.setName(debugTag);
+        TAG = debugTag;
+        this.mTrack = syncObject.mTrack;
+        this.syncObject = syncObject;
+    }
+
+    // Media track
+    private AudioTrack mTrack = null;
+
+    @Override
+    public void run() {
+        Log.i(TAG, "start");
+
+        mTrack.play();
+
+        try {
+            int idx = 0;
+            while (running) {
+                synchronized (syncObject.filledLock) {
+                    while (syncObject.filled == 0) {
+                        syncObject.filledLock.wait();
+                        if (!running) {
+                            throw new Exception("Not running");
+                        }
+                    }
+                }
+
+                mTrack.write(syncObject.byteArray[idx], 0,
+                        syncObject.packet_size);
+
+                idx = (++idx) % WorkerThreadPair.NUM_PKTS;
+
+                synchronized (syncObject.filledLock) {
+                    syncObject.filled--;
+                    syncObject.filledLock.notifyAll();
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "exception:" + e);
+        }
+
+        // Do some cleanup
+        mTrack.stop();
+        mTrack.release();
+        mTrack = null;
+        Log.i(TAG, "done");
+    }
+}

--- a/src/main/java/com/kaytat/simpleprotocolplayer/NetworkReadThread.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/NetworkReadThread.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ * Copyright (C) 2014 kaytat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kaytat.simpleprotocolplayer;
+
+import java.io.DataInputStream;
+import java.net.Socket;
+
+import android.util.Log;
+
+/**
+ * Worker thread reads data from the network
+ */
+class NetworkReadThread extends ThreadStoppable {
+    final String TAG;
+
+    WorkerThreadPair syncObject;
+    String ipAddr;
+    int port;
+    Socket socket;
+
+    // socket timeout at 5 seconds
+    static final int SOCKET_TIMEOUT = 5 * 1000;
+
+    public NetworkReadThread(WorkerThreadPair syncObject, String ipAddr,
+            int port, String debugTag) {
+        this.TAG = debugTag;
+        this.setName(debugTag);
+        this.syncObject = syncObject;
+        this.ipAddr = ipAddr;
+        this.port = port;
+    }
+
+    @Override
+    public void run() {
+        Log.i(TAG, "start");
+
+        byte[] tmpBuf = new byte[syncObject.packet_size];
+        try {
+            // Create the TCP socket and setup some parameters
+            socket = new Socket(ipAddr, port);
+            DataInputStream is = new DataInputStream(socket.getInputStream());
+            try {
+                socket.setSoTimeout(SOCKET_TIMEOUT);
+                socket.setTcpNoDelay(true);
+            } catch (Exception e) {
+                Log.i(TAG, "exception:" + e);
+                return;
+            }
+
+            Log.i(TAG, "running");
+            int idx = 0;
+
+            while (running) {
+                synchronized (syncObject.filledLock) {
+                    while (syncObject.filled == WorkerThreadPair.NUM_PKTS) {
+                        syncObject.filledLock.wait();
+                        if (!running) {
+                            throw new Exception("Not running");
+                        }
+                    }
+                }
+
+                // Get a packet
+                is.readFully(syncObject.byteArray[idx]);
+                idx++;
+                if (idx == WorkerThreadPair.NUM_PKTS) {
+                    idx = 0;
+                }
+                synchronized (syncObject.filledLock) {
+                    syncObject.filled++;
+                    if (syncObject.filled == WorkerThreadPair.NUM_PKTS) {
+                        Log.i(TAG, "flushing");
+                        // Filled up. Throw away everything that's in the
+                        // network queue.
+                        int rd;
+                        do {
+                            rd = is.read(tmpBuf);
+                        } while (rd == syncObject.packet_size && running);
+                    }
+                    syncObject.filledLock.notifyAll();
+                }
+            }
+        } catch (Exception e) {
+            Log.i(TAG, "exception:" + e);
+        }
+
+        try {
+            if (socket != null) {
+                socket.close();
+            }
+            if (running) {
+
+                syncObject.brokenShutdown();
+            }
+        } catch (Exception e) {
+            Log.i(TAG, "exception while closing:" + e);
+        }
+
+        Log.i(TAG, "done");
+    }
+}

--- a/src/main/java/com/kaytat/simpleprotocolplayer/ThreadStoppable.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/ThreadStoppable.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ * Copyright (C) 2014 kaytat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kaytat.simpleprotocolplayer;
+
+class ThreadStoppable extends Thread {
+    volatile boolean running = true;
+
+    public void customStop() {
+        running = false;
+    }
+}

--- a/src/main/java/com/kaytat/simpleprotocolplayer/WorkerThreadPair.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/WorkerThreadPair.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ * Copyright (C) 2014 kaytat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kaytat.simpleprotocolplayer;
+
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioTrack;
+import android.os.Handler;
+import android.util.Log;
+import android.widget.Toast;
+
+/**
+ * group everything belongs a stream together,makes multi stream easier
+ * including NetworkReadThread BufferToAudioTrackThread and AudioTrack
+ * 
+ */
+public class WorkerThreadPair {
+
+    private static final String TAG = WorkerThreadPair.class.getSimpleName();
+
+    private BufferToAudioTrackThread audioThread;
+    private NetworkReadThread networkThread;
+    AudioTrack mTrack;
+
+    public WorkerThreadPair(MusicService musicService, String serverAddr,
+            int serverPort, int sample_rate, boolean stereo, int buffer_ms) {
+        this.musicService=musicService;
+        int format = stereo ? AudioFormat.CHANNEL_OUT_STEREO
+                : AudioFormat.CHANNEL_OUT_MONO;
+
+        // Sanitize input, just in case
+        if (sample_rate <= 0) {
+            sample_rate = MusicService.DEFAULT_SAMPLE_RATE;
+        }
+
+        if (buffer_ms <= 5) {
+            buffer_ms = MusicService.DEFAULT_BUFFER_MS;
+        }
+
+        int minBuf = AudioTrack.getMinBufferSize(sample_rate, format,
+                AudioFormat.ENCODING_PCM_16BIT);
+
+        packet_size = calcPacketSize(sample_rate, stereo, minBuf, buffer_ms);
+
+        for (int i = 0; i < NUM_PKTS; i++) {
+            byteArray[i] = new byte[packet_size];
+        }
+
+        // The agreement here is that mTrack will be shutdown by the helper
+        mTrack = new AudioTrack(AudioManager.STREAM_MUSIC, sample_rate, format,
+                AudioFormat.ENCODING_PCM_16BIT, minBuf, AudioTrack.MODE_STREAM);
+
+        audioThread = new BufferToAudioTrackThread(this, "audio:"
+                + serverAddr + ":" + serverPort);
+        networkThread = new NetworkReadThread(this, serverAddr, serverPort,
+                "net:" + serverAddr + ":" + serverPort);
+
+        audioThread.start();
+        networkThread.start();
+    }
+
+    static int calcPacketSize(int sample_rate, boolean stereo, int minBuf,
+            int buffer_ms) {
+
+        // Assume 16 bits per sample
+        int bytesPerSecond = sample_rate * 2;
+        if (stereo) {
+            bytesPerSecond *= 2;
+        }
+
+        int result = (bytesPerSecond * buffer_ms) / 1000;
+
+        if ((result & 1) != 0) {
+            result++;
+        }
+
+        Log.d(TAG, "initNetworkData:bytes / second:" + (bytesPerSecond));
+        Log.d(TAG, "initNetworkData:minBuf:" + minBuf);
+        Log.d(TAG, "initNetworkData:packet_size:" + result);
+
+        return result;
+    }
+
+    static public final int NUM_PKTS = 3;
+
+    // The amount of data to read from the network before sending to AudioTrack
+    int packet_size;
+
+    final Object filledLock = new Object();
+    int filled = 0;
+    byte[][] byteArray = new byte[NUM_PKTS][];
+
+    public void stopAndInterrupt() {
+        for (ThreadStoppable it : new ThreadStoppable[] { audioThread,
+                networkThread }) {
+
+            try {
+                it.customStop();
+                it.interrupt();
+
+                // Do not join since this can take some time. The
+                // workers should be able to shutdown independently.
+                // t.join();
+            } catch (Exception e) {
+                Log.e(TAG, "join exception:" + e);
+            }
+        }
+    }
+
+    private MusicService musicService;
+
+    public void brokenShutdown() {
+        // Broke out of loop unexpectedly. Shutdown.
+        Handler h = new Handler(musicService.getMainLooper());
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(musicService.getApplicationContext(),
+                        "Unable to stream", Toast.LENGTH_SHORT).show();
+                musicService.processStopRequest();
+            }
+        };
+        h.post(r);
+    }
+}


### PR DESCRIPTION
It's wonderful that SPP makes android  a pulseaudio sink, 
I wonder if any interests to support multi host steaming ?
this is a quick hack to implement multi streaming and it works
(just add background read/play function, no UI 
MusicService.java line 220 just hardcoded another host for test purpose . )
hopes SPP become more powerful.  

I test this on an old mtk 6577 phone (dual-1G ,512ram) it can
mix  6x  44K stereo 16bit streams (maybe this is not max limit)

this makes SPP  act as a wireless shared output, not limited to 
one host
