### PR TITLE
Acquire wifi wake lock when starting playback.

### DIFF
--- a/src/main/java/com/kaytat/simpleprotocolplayer/MusicService.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/MusicService.java
@@ -470,6 +470,8 @@ public class MusicService extends Service implements MusicFocusable {
         bufferToAudioTrackWorkerThread.start();
         networkReadWorkerThread.start();
 
+        mWifiLock.acquire();
+
         mState = State.Playing;
         configVolume();
 


### PR DESCRIPTION
On one of the two devices I'm running the application on, the stream always stops after 17 minutes. Checking the code, I noticed a wifi wake lock was created and released, but never acquired. This PR adds the lock acquisition and fixes the issue for me. 
When merging the multi-stream PR, this code will probably break, as some logic will be required to keep track of playing streams and release the lock (in _MusicService.relaxResources()_) only when the last stream has stopped playing.
