### PR TITLE
use ArrayBlockingQueue to improve concurrency and data drop logic

### DIFF
--- a/src/main/java/com/kaytat/simpleprotocolplayer/BufferToAudioTrackThread.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/BufferToAudioTrackThread.java
@@ -45,26 +45,9 @@ class BufferToAudioTrackThread extends ThreadStoppable {
         mTrack.play();
 
         try {
-            int idx = 0;
             while (running) {
-                synchronized (syncObject.filledLock) {
-                    while (syncObject.filled == 0) {
-                        syncObject.filledLock.wait();
-                        if (!running) {
-                            throw new Exception("Not running");
-                        }
-                    }
-                }
-
-                mTrack.write(syncObject.byteArray[idx], 0,
+                mTrack.write(syncObject.dataQueue.take(), 0,
                         syncObject.packet_size);
-
-                idx = (++idx) % WorkerThreadPair.NUM_PKTS;
-
-                synchronized (syncObject.filledLock) {
-                    syncObject.filled--;
-                    syncObject.filledLock.notifyAll();
-                }
             }
         } catch (Exception e) {
             Log.e(TAG, "exception:" + e);

--- a/src/main/java/com/kaytat/simpleprotocolplayer/WorkerThreadPair.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/WorkerThreadPair.java
@@ -17,6 +17,8 @@
 
 package com.kaytat.simpleprotocolplayer;
 
+import java.util.concurrent.ArrayBlockingQueue;
+
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
@@ -56,10 +58,6 @@ public class WorkerThreadPair {
                 AudioFormat.ENCODING_PCM_16BIT);
 
         packet_size = calcPacketSize(sample_rate, stereo, minBuf, buffer_ms);
-
-        for (int i = 0; i < NUM_PKTS; i++) {
-            byteArray[i] = new byte[packet_size];
-        }
 
         // The agreement here is that mTrack will be shutdown by the helper
         mTrack = new AudioTrack(AudioManager.STREAM_MUSIC, sample_rate, format,
@@ -101,9 +99,8 @@ public class WorkerThreadPair {
     // The amount of data to read from the network before sending to AudioTrack
     int packet_size;
 
-    final Object filledLock = new Object();
-    int filled = 0;
-    byte[][] byteArray = new byte[NUM_PKTS][];
+    final ArrayBlockingQueue<byte[]> dataQueue = new ArrayBlockingQueue<byte[]>(
+            NUM_PKTS);
 
     public void stopAndInterrupt() {
         for (ThreadStoppable it : new ThreadStoppable[] { audioThread,


### PR DESCRIPTION
1.ArrayBlockingQueue api already provides waiting/non-blocking/atomic ,
makes implementation simpler
2.previously audio thread may wait network thread dropping data before taking
from queue. log shows lots drops.  with ArrayBlockingQueue , drop happens only after
 next buffer is read, during this time audio thread still have opportunity to take data . log shows
almost no drop.
