### PR TITLE
Added compatibility for API levels [8 - 13]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ allprojects {
 apply plugin: 'com.android.application'
 android {
     compileSdkVersion 17
-    buildToolsVersion "22.0.1"
+    buildToolsVersion '23.0.2'
     defaultConfig {
         applicationId "com.kaytat.simpleprotocolplayer"
-        minSdkVersion 14
+        minSdkVersion 8
         targetSdkVersion 17
     }
     buildTypes {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
     android:versionName="0.5.4.0">
 
     <uses-sdk
-        android:minSdkVersion="14"
+        android:minSdkVersion="8"
         android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -36,7 +36,7 @@
         <activity
             android:name="com.kaytat.simpleprotocolplayer.MainActivity"
             android:label="@string/app_title"
-            android:theme="@android:style/Theme.Holo.Light" >
+            android:theme="@style/theme_light" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -46,7 +46,7 @@
         <activity
             android:name="com.kaytat.simpleprotocolplayer.NoticeActivity"
             android:label="@string/notice_title"
-            android:theme="@android:style/Theme.Holo.Light.NoActionBar" >
+            android:theme="@style/theme_light_nobar" >
         </activity>
 
         <service

--- a/src/main/java/com/kaytat/simpleprotocolplayer/MainActivity.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/MainActivity.java
@@ -152,11 +152,11 @@ public class MainActivity extends Activity implements OnClickListener {
         String jsonString = prefs.getString(keyJson, null);
         ArrayList<String> arrayList = new ArrayList<String>();
 
-        if (jsonString == null || jsonString.length()==0)
+        if (jsonString == null || jsonString.length() == 0)
         {
             // Try to fill with the original key used
             String single = prefs.getString(keySingle, null);
-            if (single != null && single.length()!=0)
+            if (single != null && single.length() != 0)
             {
                 arrayList.add(single);
             }
@@ -174,7 +174,7 @@ public class MainActivity extends Activity implements OnClickListener {
                     for (int i = 0; i < jsonArray.length(); i++)
                     {
                         String s = (String)jsonArray.get(i);
-                        if (s != null && s.length()!=0)
+                        if (s != null && s.length() != 0)
                         {
                             arrayList.add((String)s);
                         }
@@ -447,7 +447,7 @@ public class MainActivity extends Activity implements OnClickListener {
             // Get the latest buffer entry
             EditText e = (EditText)findViewById(R.id.editTextBufferSize);
             String bufferMsString = e.getText().toString();
-            if (bufferMsString.length()!=0) {
+            if (bufferMsString.length() != 0) {
                 try {
                     mBufferMs = Integer.parseInt(bufferMsString);
                     Log.d(TAG, "buffer ms:" + mBufferMs);

--- a/src/main/java/com/kaytat/simpleprotocolplayer/MainActivity.java
+++ b/src/main/java/com/kaytat/simpleprotocolplayer/MainActivity.java
@@ -152,11 +152,11 @@ public class MainActivity extends Activity implements OnClickListener {
         String jsonString = prefs.getString(keyJson, null);
         ArrayList<String> arrayList = new ArrayList<String>();
 
-        if (jsonString == null || jsonString.isEmpty())
+        if (jsonString == null || jsonString.length()==0)
         {
             // Try to fill with the original key used
             String single = prefs.getString(keySingle, null);
-            if (single != null && !single.isEmpty())
+            if (single != null && single.length()!=0)
             {
                 arrayList.add(single);
             }
@@ -174,7 +174,7 @@ public class MainActivity extends Activity implements OnClickListener {
                     for (int i = 0; i < jsonArray.length(); i++)
                     {
                         String s = (String)jsonArray.get(i);
-                        if (s != null && !s.isEmpty())
+                        if (s != null && s.length()!=0)
                         {
                             arrayList.add((String)s);
                         }
@@ -245,14 +245,30 @@ public class MainActivity extends Activity implements OnClickListener {
         prefsEditor.putInt(RATE_PREF, mSampleRate);
         prefsEditor.putInt(BUFFER_MS_PREF, mBufferMs);
         prefsEditor.putBoolean(RETRY_PREF, mRetry);
-        prefsEditor.apply();
+        if (android.os.Build.VERSION.SDK_INT >= 9) {
+            prefsEditor.apply();
+        } else {
+            prefsEditor.commit();
+        }
 
         // Update adapters
         mIPAddrAdapter.clear();
-        mIPAddrAdapter.addAll(mIPAddrList);
+        if (android.os.Build.VERSION.SDK_INT >= 11) {
+            mIPAddrAdapter.addAll(mIPAddrList);
+        } else {
+            for(String ip:mIPAddrList) {
+                mIPAddrAdapter.add(ip);
+            }
+        }
         mIPAddrAdapter.notifyDataSetChanged();
         mAudioPortAdapter.clear();
-        mAudioPortAdapter.addAll(mAudioPortList);
+        if (android.os.Build.VERSION.SDK_INT >= 11) {
+            mAudioPortAdapter.addAll(mAudioPortList);
+        } else {
+            for(String port:mAudioPortList) {
+                mAudioPortAdapter.add(port);
+            }
+        }
         mAudioPortAdapter.notifyDataSetChanged();
     }
 
@@ -431,7 +447,7 @@ public class MainActivity extends Activity implements OnClickListener {
             // Get the latest buffer entry
             EditText e = (EditText)findViewById(R.id.editTextBufferSize);
             String bufferMsString = e.getText().toString();
-            if (!bufferMsString.isEmpty()) {
+            if (bufferMsString.length()!=0) {
                 try {
                     mBufferMs = Integer.parseInt(bufferMsString);
                     Log.d(TAG, "buffer ms:" + mBufferMs);

--- a/src/main/res/layout/main.xml
+++ b/src/main/res/layout/main.xml
@@ -46,6 +46,7 @@
 
             <AutoCompleteTextView
                 android:id="@+id/editTextIpAddr"
+                android:textColor="#000000"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_toRightOf="@+id/center"
@@ -75,6 +76,7 @@
 
             <AutoCompleteTextView
                 android:id="@+id/editTextAudioPort"
+                android:textColor="#000000"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_toRightOf="@+id/center2"

--- a/src/main/res/layout/main.xml
+++ b/src/main/res/layout/main.xml
@@ -206,7 +206,6 @@
 
             <Button
                 android:id="@+id/playbutton"
-                style="?android:attr/borderlessButtonStyle"
                 android:layout_width="64dp"
                 android:layout_height="64dp"
                 android:layout_margin="5dp"
@@ -214,7 +213,6 @@
 
             <Button
                 android:id="@+id/stopbutton"
-                style="?android:attr/borderlessButtonStyle"
                 android:layout_width="64dp"
                 android:layout_height="64dp"
                 android:layout_margin="5dp"

--- a/src/main/res/values-v14/styles.xml
+++ b/src/main/res/values-v14/styles.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="theme_light" parent="android:Theme.Holo.Light"/>
+    <style name="theme_light_nobar" parent="android:Theme.Holo.Light.NoActionBar"/>
+</resources>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="theme_light" parent="android:Theme.Light"/>
+    <style name="theme_light_nobar" parent="android:Theme.Light"/>
+</resources>


### PR DESCRIPTION
With only a few trivial changes, the app becomes compatible with API
levels 8 - 13.

Tested and confirmed working on a Motorola Milestone running 2.3.7 
(API v10) and a Sony Xperia Z1 running 5.1.1 (API v22).
